### PR TITLE
Make sure firewall is permanently turned off and httpd is running after a reboot.

### DIFF
--- a/install-httpd.sh
+++ b/install-httpd.sh
@@ -65,7 +65,10 @@ chown -R rundeck:apache /var/www/html/anvils
 # start the httpd service
 service httpd start
 
+# Ensure httpd is started on reboot of machine
+chkconfig httpd on
 
 
 # turn off fire wall
 service iptables stop
+chkconfig iptables off


### PR DESCRIPTION
Without this patch, executing:

```
vagrant up rundeck
vagrant halt
vagrant up rundeck
```

will not start httpd automatically and rundeck itself is not accessible because
iptables blocks all ports except of ssh port 22.
