### PR TITLE
Add missing acl policy for ssh keys kept in storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.vagrant/

--- a/aclpolicy/keys.aclpolicy
+++ b/aclpolicy/keys.aclpolicy
@@ -1,0 +1,25 @@
+---
+for:
+  storage:
+  - allow: read
+    match:
+      name: id_rsa
+      path: 'keys/acme/anvils/.*/id_rsa'
+description: 'Allow to read ssh keys'
+context:
+  application: rundeck
+by:
+  group: [dev,releng,ops]
+
+---
+for:
+  storage:
+  - allow: read
+    match:
+      name: id_rsa
+      path: '/keys/acme/anvils/.*'
+description: 'Allow to read ssh keys'
+context:
+  application: rundeck
+by:
+  group: [dev,releng,ops]


### PR DESCRIPTION
There was no policy defined for ssh keys and you couldn't execute anything.