### PR TITLE
set permissions on jobs files so that rd-jobs can load them as the rundeck user

### DIFF
--- a/add-project.sh
+++ b/add-project.sh
@@ -143,6 +143,7 @@ cp -r /vagrant/jobs/*    /var/www/html/$PROJECT/jobs/
 cp -r /vagrant/scripts/* /var/www/html/$PROJECT/scripts/
 cp -r /vagrant/options/* /var/www/html/$PROJECT/options/
 chown -R apache:rundeck /var/www/html/$PROJECT/{scripts,options,jobs}
+chmod 640 /var/www/html/$PROJECT/jobs/*
 
 # Load the jobs
 for job in /var/www/html/$PROJECT/jobs/*.xml


### PR DESCRIPTION
in the add-project part of the provisioning process, I was consistently hitting this error:
    ==> rundeck: Error: Could not upload file in request to server: /var/www/html/anvils/jobs/nightly_catalog_rebuild.xml

I think the cause of the error was that the rd-jobs command could not read the file it was uploading to the server.  After making the files also readable by the rundeck group (they are already set to uid:gid apache:rundeck), rd-jobs can read those files and we end up with a complete deployment.

Thanks for setting up this demo as a codebase! Great to have a working example on day 1.